### PR TITLE
Fix conflict with lxpolkit on lxde

### DIFF
--- a/xfce-polkit.desktop.in
+++ b/xfce-polkit.desktop.in
@@ -5,3 +5,4 @@ Comment=Policykit Authentication Agent
 Exec=@xfce_polkit_libexecdir@/xfce-polkit
 Icon=gtk-dialog-authentication
 NotShowIn=GNOME;KDE;
+OnlyShowIn=XFCE;


### PR DESCRIPTION
xfce-polkit only start with xfce session.
when we install xfce+lxde, lxpolkit and xfce4-polkit conflict. 

We must add `OnlyShowIn=XFCE;` for fixing this issue