### PR TITLE
Put authentication window at the center of the screen

### DIFF
--- a/src/xfce-polkit-listener.c
+++ b/src/xfce-polkit-listener.c
@@ -215,6 +215,7 @@ static void initiate_authentication(PolkitAgentListener  *listener,
 			NULL);
 	xfce_titled_dialog_set_subtitle(XFCE_TITLED_DIALOG(d->auth_dlg), message);
 	gtk_window_set_icon_name(GTK_WINDOW(d->auth_dlg), "dialog-password");
+	gtk_window_set_position(GTK_WINDOW(d->auth_dlg), GTK_WIN_POS_CENTER_ALWAYS);
 
 	content = gtk_dialog_get_content_area(GTK_DIALOG(d->auth_dlg));
 


### PR DESCRIPTION
At this point authentication window which asks for user's password appears in the right top corner of the screen which may be quite inconvenient especially when using on a system with a big monitor.
So this commit comes with just one line that puts authentication window in the center of the screen by default.