### PR TITLE
Don't use both NotShowIn and OnlyShowIn

### DIFF
--- a/xfce-polkit.desktop.in
+++ b/xfce-polkit.desktop.in
@@ -4,5 +4,4 @@ Name=XFCE PolKit
 Comment=Policykit Authentication Agent
 Exec=@xfce_polkit_libexecdir@/xfce-polkit
 Icon=gtk-dialog-authentication
-NotShowIn=GNOME;KDE;
 OnlyShowIn=XFCE;


### PR DESCRIPTION
According to the XDG Autostart specification, the desktop file may have either NotShowIn or OnlyShowIn but not both. It also doesn't really make much sense to have both.

https://specifications.freedesktop.org/autostart-spec/0.5/